### PR TITLE
Show flags as kebab-case in addition to options

### DIFF
--- a/include/structopt/string.hpp
+++ b/include/structopt/string.hpp
@@ -15,6 +15,12 @@ static inline bool string_replace(std::string &str, const std::string &from,
   return true;
 }
 
+inline std::string string_to_kebab(std::string str) {
+  // Generate kebab case and present as option
+  details::string_replace(str, "_", "-");
+  return str;
+}
+
 } // namespace details
 
 } // namespace structopt

--- a/include/structopt/visitor.hpp
+++ b/include/structopt/visitor.hpp
@@ -113,6 +113,16 @@ struct visitor {
       if (flag_field_names.empty() == false) {
         os << "\n\nFLAGS:\n";
         for (auto &flag : flag_field_names) {
+
+          // Generate kebab case and present as flag
+          auto kebab_case = details::string_to_kebab(flag);
+          std::string long_form = "";
+          if (kebab_case != flag) {
+            long_form = kebab_case;
+          } else {
+            long_form = flag;
+          }
+
           os << "    -" << flag[0] << ", --" << flag << "\n";
         }
       } else {
@@ -124,8 +134,7 @@ struct visitor {
         for (auto &option : optional_field_names) {
 
           // Generate kebab case and present as option
-          auto kebab_case = option;
-          details::string_replace(kebab_case, "_", "-");
+          auto kebab_case = details::string_to_kebab(option);
           std::string long_form = "";
           if (kebab_case != option) {
             long_form = kebab_case;

--- a/single_include/structopt/structopt.hpp
+++ b/single_include/structopt/structopt.hpp
@@ -2427,6 +2427,12 @@ static inline bool string_replace(std::string &str, const std::string &from,
   return true;
 }
 
+inline std::string string_to_kebab(std::string str) {
+  // Generate kebab case and present as option
+  details::string_replace(str, "_", "-");
+  return str;
+}
+
 } // namespace details
 
 } // namespace structopt
@@ -2652,6 +2658,16 @@ struct visitor {
       if (flag_field_names.empty() == false) {
         os << "\n\nFLAGS:\n";
         for (auto &flag : flag_field_names) {
+
+          // Generate kebab case and present as flag
+          auto kebab_case = details::string_to_kebab(flag);
+          std::string long_form = "";
+          if (kebab_case != flag) {
+            long_form = kebab_case;
+          } else {
+            long_form = flag;
+          }
+
           os << "    -" << flag[0] << ", --" << flag << "\n";
         }
       } else {


### PR DESCRIPTION
`structopt` supports interpreting flags as kebab-case, but in help, they are printed out as snake_case although options are shown as kebab-case.
This PR implements a feature to print flags as kebab-case as well as options do.