### PR TITLE
Fix help message for --version and --help

### DIFF
--- a/include/structopt/visitor.hpp
+++ b/include/structopt/visitor.hpp
@@ -110,6 +110,8 @@ struct visitor {
         os << field << " ";
       }
 
+      bool has_h = false;
+      bool has_v = false;
       if (flag_field_names.empty() == false) {
         os << "\n\nFLAGS:\n";
         for (auto &flag : flag_field_names) {
@@ -124,6 +126,15 @@ struct visitor {
           }
 
           os << "    -" << flag[0] << ", --" << flag << "\n";
+
+          switch (flag[0]) {
+          case 'h':
+            has_h = true;
+            break;
+          case 'v':
+            has_v = true;
+            break;
+          }
         }
       } else {
         os << "\n";
@@ -142,8 +153,21 @@ struct visitor {
             long_form = option;
           }
 
-          os << "    -" << option[0] << ", --" << long_form << " <" << option << ">"
-            << "\n";
+          if ((has_v && option == "version") || (has_h && option == "help")) {
+            os << "    --" << long_form << " <" << option << ">\n";
+          } else {
+            os << "    -" << option[0] << ", --" << long_form << " <" << option << ">"
+               << "\n";
+          }
+
+          switch (option[0]) {
+          case 'h':
+            has_h = true;
+            break;
+          case 'v':
+            has_v = true;
+            break;
+          }
         }
       }
 

--- a/single_include/structopt/structopt.hpp
+++ b/single_include/structopt/structopt.hpp
@@ -2679,8 +2679,7 @@ struct visitor {
         for (auto &option : optional_field_names) {
 
           // Generate kebab case and present as option
-          auto kebab_case = option;
-          details::string_replace(kebab_case, "_", "-");
+          auto kebab_case = details::string_to_kebab(option);
           std::string long_form = "";
           if (kebab_case != option) {
             long_form = kebab_case;

--- a/single_include/structopt/structopt.hpp
+++ b/single_include/structopt/structopt.hpp
@@ -2655,6 +2655,8 @@ struct visitor {
         os << field << " ";
       }
 
+      bool has_h = false;
+      bool has_v = false;
       if (flag_field_names.empty() == false) {
         os << "\n\nFLAGS:\n";
         for (auto &flag : flag_field_names) {
@@ -2669,6 +2671,15 @@ struct visitor {
           }
 
           os << "    -" << flag[0] << ", --" << flag << "\n";
+
+          switch (flag[0]) {
+          case 'h':
+            has_h = true;
+            break;
+          case 'v':
+            has_v = true;
+            break;
+          }
         }
       } else {
         os << "\n";
@@ -2687,8 +2698,21 @@ struct visitor {
             long_form = option;
           }
 
-          os << "    -" << option[0] << ", --" << long_form << " <" << option << ">"
-            << "\n";
+          if ((has_v && option == "version") || (has_h && option == "help")) {
+            os << "    --" << long_form << " <" << option << ">\n";
+          } else {
+            os << "    -" << option[0] << ", --" << long_form << " <" << option << ">"
+               << "\n";
+          }
+
+          switch (option[0]) {
+          case 'h':
+            has_h = true;
+            break;
+          case 'v':
+            has_v = true;
+            break;
+          }
         }
       }
 


### PR DESCRIPTION
Current `structopt` generates a help message like below:

```
USAGE: my_app [FLAGS] [OPTIONS] config_file files

FLAGS:
    -v, --verbose

OPTIONS:
    -b, --bind-address <bind_address>
    -l, --log-level <log_level>
    -u, --user <user>
    -h, --help <help>
    -v, --version <version>

ARGS:
    config_file
    files
```

However, it doesn't accept `-v` as `--version` because user-declared options like `-v` as `--verbose` are preferred. `--help` is in the same situation.

This PR fixes the help message if `-v` or `-h` doesn't work as `--version` or `--help` .