### PR TITLE
Use std::string_view where appropriate

### DIFF
--- a/include/structopt/app.hpp
+++ b/include/structopt/app.hpp
@@ -69,7 +69,7 @@ public:
           // this positional argument is not a vector-like argument
           // it expects value(s)
           throw structopt::exception("Error: expected value for positional argument `" +
-                                         field_name + "`.",
+                                         std::string(field_name.begin(), field_name.end()) + "`.",
                                      parser.visitor);
         }
       }

--- a/include/structopt/app.hpp
+++ b/include/structopt/app.hpp
@@ -18,8 +18,8 @@ class app {
   details::visitor visitor;
 
 public:
-  explicit app(const std::string &name, const std::string &version = "", const std::string& help = "")
-      : visitor(name, version, help) {}
+  explicit app(const std::string name, const std::string version = "", const std::string help = "")
+      : visitor(std::move(name), std::move(version), std::move(help)) {}
 
   template <typename T> T parse(const std::vector<std::string> &arguments) {
     T argument_struct = T();

--- a/include/structopt/app.hpp
+++ b/include/structopt/app.hpp
@@ -69,7 +69,7 @@ public:
           // this positional argument is not a vector-like argument
           // it expects value(s)
           throw structopt::exception("Error: expected value for positional argument `" +
-                                         std::string(field_name.begin(), field_name.end()) + "`.",
+                                         std::string(field_name) + "`.",
                                      parser.visitor);
         }
       }

--- a/include/structopt/app.hpp
+++ b/include/structopt/app.hpp
@@ -18,7 +18,7 @@ class app {
   details::visitor visitor;
 
 public:
-  explicit app(const std::string name, const std::string version = "", const std::string help = "")
+  explicit app(std::string name, std::string version = "", std::string help = "")
       : visitor(std::move(name), std::move(version), std::move(help)) {}
 
   template <typename T> T parse(const std::vector<std::string> &arguments) {

--- a/include/structopt/is_number.hpp
+++ b/include/structopt/is_number.hpp
@@ -6,22 +6,22 @@ namespace structopt {
 
 namespace details {
 
-static inline bool is_binary_notation(const std::string_view input) {
+static inline bool is_binary_notation(std::string_view input) {
   return input.compare(0, 2, "0b") == 0 && input.size() > 2 &&
          input.find_first_not_of("01", 2) == std::string_view::npos;
 }
 
-static inline bool is_hex_notation(const std::string_view input) {
+static inline bool is_hex_notation(std::string_view input) {
   return input.compare(0, 2, "0x") == 0 && input.size() > 2 &&
          input.find_first_not_of("0123456789abcdefABCDEF", 2) == std::string_view::npos;
 }
 
-static inline bool is_octal_notation(const std::string_view input) {
+static inline bool is_octal_notation(std::string_view input) {
   return input.compare(0, 1, "0") == 0 && input.size() > 1 &&
          input.find_first_not_of("01234567", 1) == std::string_view::npos;
 }
 
-static inline bool is_valid_number(const std::string_view input) {
+static inline bool is_valid_number(std::string_view input) {
   if (is_binary_notation(input) || is_hex_notation(input) || is_octal_notation(input)) {
     return true;
   }

--- a/include/structopt/is_number.hpp
+++ b/include/structopt/is_number.hpp
@@ -1,27 +1,27 @@
 
 #pragma once
-#include <string>
+#include <string_view>
 
 namespace structopt {
 
 namespace details {
 
-static inline bool is_binary_notation(std::string const &input) {
+static inline bool is_binary_notation(const std::string_view input) {
   return input.compare(0, 2, "0b") == 0 && input.size() > 2 &&
-         input.find_first_not_of("01", 2) == std::string::npos;
+         input.find_first_not_of("01", 2) == std::string_view::npos;
 }
 
-static inline bool is_hex_notation(std::string const &input) {
+static inline bool is_hex_notation(const std::string_view input) {
   return input.compare(0, 2, "0x") == 0 && input.size() > 2 &&
-         input.find_first_not_of("0123456789abcdefABCDEF", 2) == std::string::npos;
+         input.find_first_not_of("0123456789abcdefABCDEF", 2) == std::string_view::npos;
 }
 
-static inline bool is_octal_notation(std::string const &input) {
+static inline bool is_octal_notation(const std::string_view input) {
   return input.compare(0, 1, "0") == 0 && input.size() > 1 &&
-         input.find_first_not_of("01234567", 1) == std::string::npos;
+         input.find_first_not_of("01234567", 1) == std::string_view::npos;
 }
 
-static inline bool is_valid_number(const std::string &input) {
+static inline bool is_valid_number(const std::string_view input) {
   if (is_binary_notation(input) || is_hex_notation(input) || is_octal_notation(input)) {
     return true;
   }

--- a/include/structopt/parser.hpp
+++ b/include/structopt/parser.hpp
@@ -13,7 +13,6 @@
 #include <structopt/exception.hpp>
 #include <structopt/is_number.hpp>
 #include <structopt/is_specialization.hpp>
-#include <structopt/is_stl_container.hpp>
 #include <structopt/sub_command.hpp>
 #include <structopt/third_party/magic_enum/magic_enum.hpp>
 #include <structopt/third_party/visit_struct/visit_struct.hpp>

--- a/include/structopt/parser.hpp
+++ b/include/structopt/parser.hpp
@@ -8,10 +8,12 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <structopt/array_size.hpp>
 #include <structopt/exception.hpp>
 #include <structopt/is_number.hpp>
 #include <structopt/is_specialization.hpp>
+#include <structopt/is_stl_container.hpp>
 #include <structopt/sub_command.hpp>
 #include <structopt/third_party/magic_enum/magic_enum.hpp>
 #include <structopt/third_party/visit_struct/visit_struct.hpp>
@@ -48,7 +50,7 @@ struct parser {
   bool sub_command_invoked{false};
   std::string already_invoked_subcommand_name{""};
 
-  bool is_optional(const std::string &name) {
+  bool is_optional(const std::string_view name) {
     if (double_dash_encountered) {
       return false;
     } else if (name == "--") {
@@ -106,7 +108,7 @@ struct parser {
     return false;
   }
 
-  bool is_optional_field(const std::string &next) {
+  bool is_optional_field(const std::string_view next) {
     if (!is_optional(next)) {
       return false;
     }
@@ -126,14 +128,14 @@ struct parser {
   // and it is delimited by one of the two allowed delimiters: `=` and `:`
   //
   // if true, the return value includes the delimiter that was used
-  std::pair<bool, char> is_delimited_optional_argument(const std::string &next) {
+  std::pair<bool, char> is_delimited_optional_argument(const std::string_view next) {
     bool success = false;
     char delimiter = '\0';
 
     auto equal_pos = next.find('=');
     auto colon_pos = next.find(':');
 
-    if (equal_pos == std::string::npos && colon_pos == std::string::npos) {
+    if (equal_pos == std::string_view::npos && colon_pos == std::string_view::npos) {
       // not delimited
       return {success, delimiter};
     } else {
@@ -169,7 +171,7 @@ struct parser {
   }
 
   std::pair<std::string, std::string> split_delimited_argument(char delimiter,
-                                                               const std::string &next) {
+                                                               const std::string_view next) {
     std::string key, value;
     bool delimiter_found = false;
     for (size_t i = 0; i < next.size(); i++) {
@@ -537,10 +539,10 @@ struct parser {
 
     // Parse from current till end
     while (next_index < arguments.size()) {
-      const auto next = arguments[next_index];
-      if (is_optional_field(next) || std::string{next} == "--" ||
+      const std::string_view next = arguments[next_index];
+      if (is_optional_field(next) || next == "--" ||
           is_delimited_optional_argument(next).first) {
-        if (std::string{next} == "--") {
+        if (next == "--") {
           double_dash_encountered = true;
           next_index += 1;
         }
@@ -560,10 +562,10 @@ struct parser {
     T result;
     // Parse from current till end
     while (next_index < arguments.size()) {
-      const auto next = arguments[next_index];
-      if (is_optional_field(next) || std::string{next} == "--" ||
+      const std::string_view next = arguments[next_index];
+      if (is_optional_field(next) || next == "--" ||
           is_delimited_optional_argument(next).first) {
-        if (std::string{next} == "--") {
+        if (next == "--") {
           double_dash_encountered = true;
           next_index += 1;
         }
@@ -583,10 +585,10 @@ struct parser {
     T result;
     // Parse from current till end
     while (next_index < arguments.size()) {
-      const auto next = arguments[next_index];
-      if (is_optional_field(next) || std::string{next} == "--" ||
+      const std::string_view next = arguments[next_index];
+      if (is_optional_field(next) || next == "--" ||
           is_delimited_optional_argument(next).first) {
-        if (std::string{next} == "--") {
+        if (next == "--") {
           double_dash_encountered = true;
           next_index += 1;
         }
@@ -638,7 +640,7 @@ struct parser {
 
     if (current_index < arguments.size()) {
       const auto next = arguments[current_index];
-      const auto field_name = std::string{name};
+      const auto field_name = std::string_view{name};
 
       // Check if `next` is the start of a subcommand
       if (visitor.is_field_name(next) && next == field_name) {

--- a/include/structopt/parser.hpp
+++ b/include/structopt/parser.hpp
@@ -90,7 +90,7 @@ struct parser {
     if (next.rfind("--", 0) == 0 && next.substr(2) == field_name) {
       return true;
     }
-    if (next == std::data({'-', field_name[0]})) {
+    if (next == std::data({'-', field_name[0], '\0'})) {
       return true;
     }
     return is_kebab_case(next, field_name);

--- a/include/structopt/parser.hpp
+++ b/include/structopt/parser.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <initializer_list>
 #include <iostream>
 #include <iterator>
 #include <set>
@@ -89,7 +90,7 @@ struct parser {
     if (next.rfind("--", 0) == 0 && next.substr(2) == field_name) {
       return true;
     }
-    if (next.size() == 2 && next[0] == '-' && next[1] == field_name[0]) {
+    if (next == std::data({'-', field_name[0]})) {
       return true;
     }
     return is_kebab_case(next, field_name);

--- a/include/structopt/parser.hpp
+++ b/include/structopt/parser.hpp
@@ -395,7 +395,7 @@ struct parser {
           // this positional argument is not a vector-like argument
           // it expects value(s)
           throw structopt::exception("Error: expected value for positional argument `" +
-                                         std::string(field_name.begin(), field_name.end()) + "`.",
+                                         std::string(field_name) + "`.",
                                      argument_struct.visitor_);
         }
       }
@@ -465,7 +465,7 @@ struct parser {
     const auto arguments_left = arguments.size() - next_index;
     if (arguments_left == 0 || arguments_left < N) {
       throw structopt::exception("Error: expected " + std::to_string(N) +
-                                     " values for std::array argument `" + std::string(name.begin(), name.end()) +
+                                     " values for std::array argument `" + std::string(name) +
                                      "` - instead got only " +
                                      std::to_string(arguments_left) + " arguments.",
                                  visitor);

--- a/include/structopt/parser.hpp
+++ b/include/structopt/parser.hpp
@@ -516,7 +516,7 @@ struct parser {
 
     // Parse from current till end
     while (next_index < arguments.size()) {
-      std::string_view next = arguments[next_index];
+      const std::string_view next = arguments[next_index];
       if (is_optional_field(next) || next == "--" ||
           is_delimited_optional_argument(next).first) {
         if (next == "--") {

--- a/include/structopt/string.hpp
+++ b/include/structopt/string.hpp
@@ -15,10 +15,11 @@ static inline bool string_replace(std::string &str, const std::string &from,
   return true;
 }
 
-inline std::string string_to_kebab(std::string str) {
+inline std::string string_to_kebab(std::string_view str) {
   // Generate kebab case and present as option
-  details::string_replace(str, "_", "-");
-  return str;
+  std::string str2(str.begin(), str.end());
+  details::string_replace(str2, "_", "-");
+  return str2;
 }
 
 } // namespace details

--- a/include/structopt/string.hpp
+++ b/include/structopt/string.hpp
@@ -1,6 +1,7 @@
 
 #pragma once
 #include <string>
+#include <string_view>
 
 namespace structopt {
 

--- a/include/structopt/visitor.hpp
+++ b/include/structopt/visitor.hpp
@@ -31,11 +31,10 @@ struct visitor {
 
   visitor() = default;
 
-  explicit visitor(const std::string name, const std::string version)
+  explicit visitor(std::string name, std::string version)
       : name(std::move(name)), version(std::move(version)) {}
 
-  explicit visitor(const std::string name, const std::string version,
-                   const std::string help)
+  explicit visitor(std::string name, std::string version, std::string help)
       : name(std::move(name)), version(std::move(version)),
         help(std::move(help)) {}
 

--- a/include/structopt/visitor.hpp
+++ b/include/structopt/visitor.hpp
@@ -47,7 +47,7 @@ struct visitor {
   template <typename T>
   inline typename std::enable_if<structopt::is_specialization<T, std::optional>::value,
                                  void>::type
-  operator()(const std::string_view name, T &) {
+  operator()(std::string_view name, T &) {
     field_names.push_back(name);
     if constexpr (std::is_same<typename T::value_type, bool>::value) {
       flag_field_names.push_back(name);
@@ -61,7 +61,7 @@ struct visitor {
   inline typename std::enable_if<!structopt::is_specialization<T, std::optional>::value &&
                                      !visit_struct::traits::is_visitable<T>::value,
                                  void>::type
-  operator()(const std::string_view name, T &) {
+  operator()(std::string_view name, T &) {
     field_names.push_back(name);
     positional_field_names.push_back(name);
     positional_field_names_for_help.push_back(name);
@@ -84,12 +84,12 @@ struct visitor {
   // Visitor function for nested structs
   template <typename T>
   inline typename std::enable_if<visit_struct::traits::is_visitable<T>::value, void>::type
-  operator()(const std::string_view name, T &) {
+  operator()(std::string_view name, T &) {
     field_names.push_back(name);
     nested_struct_field_names.push_back(name);
   }
 
-  bool is_field_name(const std::string_view field_name) {
+  bool is_field_name(std::string_view field_name) {
     return std::find(field_names.begin(), field_names.end(), field_name) !=
            field_names.end();
   }

--- a/include/structopt/visitor.hpp
+++ b/include/structopt/visitor.hpp
@@ -2,14 +2,19 @@
 #pragma once
 #include <algorithm>
 #include <iostream>
+#include <list>
 #include <optional>
 #include <queue>
+#include <set>
+#include <stack>
 #include <string>
+#include <string_view>
 #include <structopt/is_specialization.hpp>
 #include <structopt/string.hpp>
-#include <structopt/third_party/visit_struct/visit_struct.hpp>
 #include <type_traits>
+#include <unordered_set>
 #include <vector>
+#include <visit_struct/visit_struct.hpp>
 
 namespace structopt {
 
@@ -84,7 +89,7 @@ struct visitor {
     nested_struct_field_names.push_back(name);
   }
 
-  bool is_field_name(const std::string &field_name) {
+  bool is_field_name(const std::string_view field_name) {
     return std::find(field_names.begin(), field_names.end(), field_name) !=
            field_names.end();
   }

--- a/include/structopt/visitor.hpp
+++ b/include/structopt/visitor.hpp
@@ -2,19 +2,15 @@
 #pragma once
 #include <algorithm>
 #include <iostream>
-#include <list>
 #include <optional>
 #include <queue>
-#include <set>
-#include <stack>
 #include <string>
 #include <string_view>
 #include <structopt/is_specialization.hpp>
 #include <structopt/string.hpp>
+#include <structopt/third_party/visit_struct/visit_struct.hpp>
 #include <type_traits>
-#include <unordered_set>
 #include <vector>
-#include <visit_struct/visit_struct.hpp>
 
 namespace structopt {
 

--- a/include/structopt/visitor.hpp
+++ b/include/structopt/visitor.hpp
@@ -21,13 +21,13 @@ struct visitor {
   std::string name;
   std::string version;
   std::optional<std::string> help;
-  std::vector<std::string> field_names;
-  std::deque<std::string> positional_field_names; // mutated by parser
-  std::deque<std::string> positional_field_names_for_help;
-  std::deque<std::string> vector_like_positional_field_names;
-  std::deque<std::string> flag_field_names;
-  std::deque<std::string> optional_field_names;
-  std::deque<std::string> nested_struct_field_names;
+  std::vector<std::string_view> field_names;
+  std::deque<std::string_view> positional_field_names; // mutated by parser
+  std::deque<std::string_view> positional_field_names_for_help;
+  std::deque<std::string_view> vector_like_positional_field_names;
+  std::deque<std::string_view> flag_field_names;
+  std::deque<std::string_view> optional_field_names;
+  std::deque<std::string_view> nested_struct_field_names;
 
   visitor() = default;
 
@@ -43,7 +43,7 @@ struct visitor {
   template <typename T>
   inline typename std::enable_if<structopt::is_specialization<T, std::optional>::value,
                                  void>::type
-  operator()(const char *name, T &) {
+  operator()(const std::string_view name, T &) {
     field_names.push_back(name);
     if constexpr (std::is_same<typename T::value_type, bool>::value) {
       flag_field_names.push_back(name);
@@ -57,7 +57,7 @@ struct visitor {
   inline typename std::enable_if<!structopt::is_specialization<T, std::optional>::value &&
                                      !visit_struct::traits::is_visitable<T>::value,
                                  void>::type
-  operator()(const char *name, T &) {
+  operator()(const std::string_view name, T &) {
     field_names.push_back(name);
     positional_field_names.push_back(name);
     positional_field_names_for_help.push_back(name);
@@ -80,7 +80,7 @@ struct visitor {
   // Visitor function for nested structs
   template <typename T>
   inline typename std::enable_if<visit_struct::traits::is_visitable<T>::value, void>::type
-  operator()(const char *name, T &) {
+  operator()(const std::string_view name, T &) {
     field_names.push_back(name);
     nested_struct_field_names.push_back(name);
   }

--- a/include/structopt/visitor.hpp
+++ b/include/structopt/visitor.hpp
@@ -31,11 +31,13 @@ struct visitor {
 
   visitor() = default;
 
-  explicit visitor(const std::string &name, const std::string &version)
-      : name(name), version(version) {}
+  explicit visitor(const std::string name, const std::string version)
+      : name(std::move(name)), version(std::move(version)) {}
 
-  explicit visitor(const std::string &name, const std::string &version, const std::string& help)
-      : name(name), version(version), help(help) {}
+  explicit visitor(const std::string name, const std::string version,
+                   const std::string help)
+      : name(std::move(name)), version(std::move(version)),
+        help(std::move(help)) {}
 
   // Visitor function for std::optional - could be an option or a flag
   template <typename T>


### PR DESCRIPTION
Sort of a draft, sort of ready. There are probably more places where std::string could be replaced with std::string_view, but I got most of the obvious stuff. Also included a few string related changes. It's also possible I could do more, but some stuff could involve breaking changes.

@schaumb FYI, you might be interested.